### PR TITLE
Enhance home page with FAQ

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -28,6 +28,21 @@
             "✅ No use of content outside the Bible",
             "✅ Frequently updated with improvements",
             "✅ Focused on faith, learning, and Christian reflection"
+        ],
+        "faqTitle": "Frequently Asked Questions",
+        "faq": [
+            {
+                "question": "Is bAIble free to use?",
+                "answer": "Yes, bAIble is completely free and supported by non-intrusive ads."
+            },
+            {
+                "question": "Does it work offline?",
+                "answer": "No, an active internet connection is required to generate responses."
+            },
+            {
+                "question": "Are the answers accurate?",
+                "answer": "All answers are generated using AI with references from the Bible, but please verify with the Scriptures."
+            }
         ]
     },
     "versions": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -28,6 +28,21 @@
             "✅ Sin contenido externo a la Biblia",
             "✅ Mejorado constantemente con actualizaciones",
             "✅ Enfocado en la fe, el aprendizaje y la reflexión cristiana"
+        ],
+        "faqTitle": "Preguntas Frecuentes",
+        "faq": [
+            {
+                "question": "¿Es bAIble gratis?",
+                "answer": "Sí, bAIble es totalmente gratis y se mantiene con anuncios no invasivos."
+            },
+            {
+                "question": "¿Funciona sin conexión?",
+                "answer": "No, se requiere conexión a internet para generar las respuestas."
+            },
+            {
+                "question": "¿Las respuestas son precisas?",
+                "answer": "Las respuestas se generan con IA y referencias bíblicas, pero debes confirmar en las Escrituras."
+            }
         ]
     },
     "versions": {

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -28,6 +28,21 @@
             "✅ Não utiliza conteúdo fora das Escrituras",
             "✅ Atualizado constantemente com melhorias",
             "✅ Foco em aprendizado, fé e reflexão cristã"
+        ],
+        "faqTitle": "Perguntas Frequentes",
+        "faq": [
+            {
+                "question": "O bAIble é gratuito?",
+                "answer": "Sim, o bAIble é totalmente gratuito e sustentado por anúncios não invasivos."
+            },
+            {
+                "question": "Funciona offline?",
+                "answer": "Não, é necessário estar conectado à internet para gerar as respostas."
+            },
+            {
+                "question": "As respostas são precisas?",
+                "answer": "As respostas são geradas com IA utilizando trechos da Bíblia, mas sempre confira com as Escrituras."
+            }
         ]
     },
     "versions": {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -332,6 +332,26 @@
                 </ul>
             </v-col>
         </v-row>
+        <v-row class="mt-6">
+            <v-col cols="12">
+                <h2 class="text-h5 font-weight-bold mb-2">
+                    {{ $t('home.faqTitle') }}
+                </h2>
+                <v-expansion-panels>
+                    <v-expansion-panel
+                        v-for="(item, i) in $tm('home.faq')"
+                        :key="i"
+                    >
+                        <v-expansion-panel-title>
+                            {{ item.question }}
+                        </v-expansion-panel-title>
+                        <v-expansion-panel-text>
+                            {{ item.answer }}
+                        </v-expansion-panel-text>
+                    </v-expansion-panel>
+                </v-expansion-panels>
+            </v-col>
+        </v-row>
     </v-container>
     <v-footer class="footer-links">
         <v-row justify="center" class="text-center">


### PR DESCRIPTION
## Summary
- add FAQ section to home page with Vuetify expansion panels
- provide translations for new FAQ content in English, Portuguese and Spanish

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d3750d6288324a7d8f6fef5053729