### PR TITLE
Expand home page content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,76 @@
-# Vue 3 + Vite
+# bAIble Frontend
 
-This template should help get you started developing with Vue 3 in Vite. The template uses Vue 3 `<script setup>` SFCs, check out the [script setup docs](https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup) to learn more.
+bAIble is a multilingual Bible study assistant built with Vue 3 and Vite. It allows users to chat with biblical characters powered by AI while keeping the interface simple and mobile‑friendly.
 
-Learn more about IDE Support for Vue in the [Vue Docs Scaling up Guide](https://vuejs.org/guide/scaling-up/tooling.html#ide-support).
+## Features
+
+- Conversational interface for questions about Scripture
+- AI models selectable by the user
+- Supports Portuguese, English and Spanish
+- Choice of Bible versions per language
+- Responsive design using Vuetify
+- Cookie consent, privacy policy and terms pages
+- Dockerfile and Capacitor configuration for deployment
+
+## Requirements
+
+- Node.js 20+
+- npm
+- (Optional) Docker for containerized builds
+- (Optional) Android Studio if packaging the mobile app
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Configure the GraphQL endpoint in a `.env` file:
+   ```bash
+   VITE_API_URL=http://localhost:8000/graphql/
+   ```
+3. Start the development server:
+   ```bash
+   npm run dev
+   ```
+   Visit `http://localhost:5173` in your browser.
+4. Build for production:
+   ```bash
+   npm run build
+   ```
+5. Preview the production build:
+   ```bash
+   npm run preview
+   ```
+
+## Docker
+
+To create a production container:
+
+```bash
+docker build -t baible-frontend .
+docker run -p 80:80 baible-frontend
+```
+
+## Mobile (Capacitor)
+
+After building the web assets you can sync them to the Android project:
+
+```bash
+npm run build
+npx cap sync android
+```
+
+Open the `android` directory in Android Studio to run or package the app.
+
+## Project Layout
+
+- `src/` – application source code
+  - `views/` – main pages such as Home, Chat, Privacy, Terms and Contact
+  - `data/` – predefined characters, Bible versions and model options
+  - `locales/` – translation files
+  - `services/` – helper modules that call the GraphQL API
+- `public/` – static assets served at the root
+- `Dockerfile` and `nginx.conf` – used to build and serve the production image
+
+Contributions are welcome! Feel free to open issues or pull requests.

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -28,6 +28,27 @@
             "✅ No use of content outside the Bible",
             "✅ Frequently updated with improvements",
             "✅ Focused on faith, learning, and Christian reflection"
+        ],
+        "missionTitle": "Our Mission",
+        "missionContent": "Our mission is to connect people with the Word of God using cutting-edge technology so that Bible study becomes accessible and relevant to modern life.",
+        "techTitle": "Technology Behind bAIble",
+        "techContent": "bAIble uses retrieval-augmented generation to provide accurate biblical responses, combining trusted translations with advanced AI.",
+        "privacyTitle": "Privacy & Ads",
+        "privacyContent": "We respect your privacy and only collect minimal data needed to operate. Non-intrusive ads keep the service free.",
+        "faqTitle": "Frequently Asked Questions",
+        "faq": [
+            {
+                "question": "Is bAIble free to use?",
+                "answer": "Yes, bAIble is completely free and supported by non-intrusive ads."
+            },
+            {
+                "question": "Does it work offline?",
+                "answer": "No, an active internet connection is required to generate responses."
+            },
+            {
+                "question": "Are the answers accurate?",
+                "answer": "All answers are generated using AI with references from the Bible, but please verify with the Scriptures."
+            }
         ]
     },
     "versions": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -28,6 +28,27 @@
             "✅ Sin contenido externo a la Biblia",
             "✅ Mejorado constantemente con actualizaciones",
             "✅ Enfocado en la fe, el aprendizaje y la reflexión cristiana"
+        ],
+        "missionTitle": "Nuestra Misión",
+        "missionContent": "Nuestra misión es conectar a las personas con la Palabra de Dios utilizando tecnología avanzada, haciendo que el estudio bíblico sea accesible y relevante para la vida diaria.",
+        "techTitle": "Tecnología detrás de bAIble",
+        "techContent": "bAIble usa generación aumentada por búsqueda (RAG) para ofrecer respuestas bíblicas precisas, combinando traducciones confiables con IA avanzada.",
+        "privacyTitle": "Privacidad y Anuncios",
+        "privacyContent": "Respetamos tu privacidad y solo recopilamos los datos mínimos necesarios. Los anuncios no invasivos mantienen el servicio gratuito.",
+        "faqTitle": "Preguntas Frecuentes",
+        "faq": [
+            {
+                "question": "¿Es bAIble gratis?",
+                "answer": "Sí, bAIble es totalmente gratis y se mantiene con anuncios no invasivos."
+            },
+            {
+                "question": "¿Funciona sin conexión?",
+                "answer": "No, se requiere conexión a internet para generar las respuestas."
+            },
+            {
+                "question": "¿Las respuestas son precisas?",
+                "answer": "Las respuestas se generan con IA y referencias bíblicas, pero debes confirmar en las Escrituras."
+            }
         ]
     },
     "versions": {

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -28,6 +28,27 @@
             "✅ Não utiliza conteúdo fora das Escrituras",
             "✅ Atualizado constantemente com melhorias",
             "✅ Foco em aprendizado, fé e reflexão cristã"
+        ],
+        "missionTitle": "Nossa Missão",
+        "missionContent": "Nossa missão é conectar pessoas à Palavra de Deus usando tecnologia avançada, tornando o estudo bíblico acessível e relevante no dia a dia.",
+        "techTitle": "Tecnologia por Trás do bAIble",
+        "techContent": "O bAIble utiliza geração aumentada por busca (RAG) para oferecer respostas precisas, unindo traduções confiáveis a uma IA avançada.",
+        "privacyTitle": "Privacidade e Anúncios",
+        "privacyContent": "Respeitamos sua privacidade e coletamos apenas os dados mínimos necessários. Anúncios não invasivos mantêm o serviço gratuito.",
+        "faqTitle": "Perguntas Frequentes",
+        "faq": [
+            {
+                "question": "O bAIble é gratuito?",
+                "answer": "Sim, o bAIble é totalmente gratuito e sustentado por anúncios não invasivos."
+            },
+            {
+                "question": "Funciona offline?",
+                "answer": "Não, é necessário estar conectado à internet para gerar as respostas."
+            },
+            {
+                "question": "As respostas são precisas?",
+                "answer": "As respostas são geradas com IA utilizando trechos da Bíblia, mas sempre confira com as Escrituras."
+            }
         ]
     },
     "versions": {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -332,6 +332,48 @@
                 </ul>
             </v-col>
         </v-row>
+        <v-row class="mt-6">
+            <v-col cols="12" md="6">
+                <h2 class="text-h5 font-weight-bold mb-2">
+                    {{ $t('home.missionTitle') }}
+                </h2>
+                <p class="text-body-1">{{ $t('home.missionContent') }}</p>
+            </v-col>
+            <v-col cols="12" md="6">
+                <h2 class="text-h5 font-weight-bold mb-2">
+                    {{ $t('home.techTitle') }}
+                </h2>
+                <p class="text-body-1">{{ $t('home.techContent') }}</p>
+            </v-col>
+        </v-row>
+        <v-row class="mt-6">
+            <v-col cols="12">
+                <h2 class="text-h5 font-weight-bold mb-2">
+                    {{ $t('home.privacyTitle') }}
+                </h2>
+                <p class="text-body-1">{{ $t('home.privacyContent') }}</p>
+            </v-col>
+        </v-row>
+        <v-row class="mt-6">
+            <v-col cols="12">
+                <h2 class="text-h5 font-weight-bold mb-2">
+                    {{ $t('home.faqTitle') }}
+                </h2>
+                <v-expansion-panels>
+                    <v-expansion-panel
+                        v-for="(item, i) in $tm('home.faq')"
+                        :key="i"
+                    >
+                        <v-expansion-panel-title>
+                            {{ item.question }}
+                        </v-expansion-panel-title>
+                        <v-expansion-panel-text>
+                            {{ item.answer }}
+                        </v-expansion-panel-text>
+                    </v-expansion-panel>
+                </v-expansion-panels>
+            </v-col>
+        </v-row>
     </v-container>
     <v-footer class="footer-links">
         <v-row justify="center" class="text-center">


### PR DESCRIPTION
## Summary
- add mission, technology, and privacy sections to home page
- provide translated text in English, Portuguese, and Spanish

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d3750d6288324a7d8f6fef5053729